### PR TITLE
Ryser submatrices permanents calculator edge-case fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="theboss",
-    version="2.1.0",
+    version="2.1.1",
     author="Tomasz Rybotycki",
     author_email="rybotycki.tomasz+theboss@gmail.com",
     long_description=long_description,

--- a/tests/test_bs_submatrices_permanent_calculators.py
+++ b/tests/test_bs_submatrices_permanent_calculators.py
@@ -50,6 +50,12 @@ class TestSubmatricesPermanentsCalculators(unittest.TestCase):
         self._input_state[1] = self._dim - 1
         self._compute_permanents_and_assert(BSCCCHSubmatricesPermanentCalculator)
 
+    def test_chin_huh_submatrices_permanent_calculator_for_edge_case(self) -> None:
+        self._input_state = zeros(self._dim)
+        self._input_state[0] = 1
+        self._output_state = zeros(self._dim)
+        self._compute_permanents_and_assert(BSCCCHSubmatricesPermanentCalculator)
+
     def test_ryser_submatrices_permanent_calculator_for_std_input(self) -> None:
         self._input_state = ones(self._dim, dtype=int)
         self._compute_permanents_and_assert(BSCCRyserSubmatricesPermanentCalculator)
@@ -58,6 +64,12 @@ class TestSubmatricesPermanentsCalculators(unittest.TestCase):
         self._input_state = zeros(self._dim)
         self._input_state[0] = 1
         self._input_state[1] = self._dim - 1
+        self._compute_permanents_and_assert(BSCCRyserSubmatricesPermanentCalculator)
+
+    def test_ryser_submatrices_permanent_calculator_for_edge_case(self) -> None:
+        self._input_state = zeros(self._dim)
+        self._input_state[0] = 1
+        self._output_state = zeros(self._dim)
         self._compute_permanents_and_assert(BSCCRyserSubmatricesPermanentCalculator)
 
     def _compute_permanents_and_assert(

--- a/theboss/boson_sampling_utilities/permanent_calculators/bs_cc_ryser_submatrices_permanent_calculator.py
+++ b/theboss/boson_sampling_utilities/permanent_calculators/bs_cc_ryser_submatrices_permanent_calculator.py
@@ -103,7 +103,7 @@ class BSCCRyserSubmatricesPermanentCalculator(
         for i in range(len(self.permanents)):
 
             # We don't want to update permanents with the wrong r-vector sums.
-            if 0 < self._r_vector[i] == self.input_state[i]:
+            if self.input_state[i] == 0 or self._r_vector[i] == self.input_state[i]:
                 continue
 
             # We've got to update the binomials product to ensure that it reflects

--- a/theboss/boson_sampling_utilities/permanent_calculators/bs_submatrices_permanent_calculator_base.py
+++ b/theboss/boson_sampling_utilities/permanent_calculators/bs_submatrices_permanent_calculator_base.py
@@ -84,6 +84,7 @@ class BSGuanBasedSubmatricesPermanentCalculatorBase(
         super().__init__(matrix, input_state, output_state)
 
         # Guan codes related
+        self._multiplier = None
         self._index_to_update: int = 0
         self._last_value_at_index: int = 0
 
@@ -151,6 +152,11 @@ class BSGuanBasedSubmatricesPermanentCalculatorBase(
         The main method of the class. Computes the permanents of the submatrices by
         using Ryser's formula, the input-output exchange trick and the Guan codes.
         """
+
+        # Take care of the edge-case, where only 1 sub-matrix is valid (and empty).
+        if sum(self.input_state) == 1:
+            return list(self.input_state)
+
         self._initialize_permanents_computation()
 
         while self._r_vector[-1] <= self._position_limits[-1]:


### PR DESCRIPTION
fix(permanents): Fix edge-case ([1, 0, ..., 0] input) for Ryser submatrices permanents calculator.

Closing #51.